### PR TITLE
fix(theme): contriboot description field min-height

### DIFF
--- a/theme/styles/contriboot.styl
+++ b/theme/styles/contriboot.styl
@@ -136,6 +136,8 @@
             width: 65%
             margin: 5px
             height: auto
+        .medium-editor-element
+            min-height: 6em
 
     .submit-form__type-selection
         input


### PR DESCRIPTION
Fixes the minimum height of the description textarea which prevents firefox users to contribute a talk with a description due to a zero-height-textarea.